### PR TITLE
Add --force-pip-flag, logging improvements

### DIFF
--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -98,10 +98,6 @@ def get_default_parser():
                       "you'll install this program by using the --preinstall "
                       "argument. The replacement is expected to be found in "
                       "the virtualenv's bin/ directory.")
-    parser.add_option('--pip-binary', default=None,
-                      help="Path to custom pip binary which should be used "
-                           "and  copied to dh virtualenv. Should be used in "
-                           "combination with virtualenv --no-pip flag")
     parser.add_option('--force-pip-version', default=None,
                       help="Force upgrade a specific pip version in dh "
                            "dh-virtualenv")

--- a/dh_virtualenv/cmdline.py
+++ b/dh_virtualenv/cmdline.py
@@ -98,6 +98,13 @@ def get_default_parser():
                       "you'll install this program by using the --preinstall "
                       "argument. The replacement is expected to be found in "
                       "the virtualenv's bin/ directory.")
+    parser.add_option('--pip-binary', default=None,
+                      help="Path to custom pip binary which should be used "
+                           "and  copied to dh virtualenv. Should be used in "
+                           "combination with virtualenv --no-pip flag")
+    parser.add_option('--force-pip-version', default=None,
+                      help="Force upgrade a specific pip version in dh "
+                           "dh-virtualenv")
     parser.add_option('--upgrade-pip', action='store_true', default=False,
                       help='Upgrade pip to the latest available version')
     parser.add_option('--extra-pip-arg', action='append',

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -35,7 +35,6 @@ class Deployment(object):
                  extra_urls=[],
                  preinstall=[],
                  pip_tool='pip',
-                 pip_binary=None,
                  force_pip_version=None,
                  upgrade_pip=False,
                  index_url=None,
@@ -68,7 +67,6 @@ class Deployment(object):
         self.bin_dir = os.path.join(self.package_dir, 'bin')
         self.local_bin_dir = os.path.join(self.package_dir, 'local', 'bin')
 
-        self.pip_binary = pip_binary
         self.force_pip_version = force_pip_version
 
         self.preinstall = preinstall
@@ -113,7 +111,6 @@ class Deployment(object):
                    extra_urls=options.extra_index_url,
                    preinstall=options.preinstall,
                    pip_tool=options.pip_tool,
-                   pip_binary=options.pip_binary,
                    force_pip_version=options.force_pip_version,
                    upgrade_pip=options.upgrade_pip,
                    index_url=options.index_url,
@@ -165,11 +162,6 @@ class Deployment(object):
             output = subprocess.check_output([venv_pip_path, 'install', '--upgrade',
                                               'pip==%s' % (self.force_pip_version)]).strip()
             print('Output: %s' % (output))
-
-        if self.pip_binary:
-            dest_path = self.venv_bin('pip')
-            print("Copying %s pip binary into dh virtualenv: %s..." % (self.pip_binary, dest_path))
-            shutil.copy(self.pip_binary, dest_path)
 
         # To make troubleshooting, etc. easier, we also print which versions
         # were copied and used into venv

--- a/dh_virtualenv/deployment.py
+++ b/dh_virtualenv/deployment.py
@@ -35,6 +35,8 @@ class Deployment(object):
                  extra_urls=[],
                  preinstall=[],
                  pip_tool='pip',
+                 pip_binary=None,
+                 force_pip_version=None,
                  upgrade_pip=False,
                  index_url=None,
                  setuptools=False,
@@ -65,6 +67,9 @@ class Deployment(object):
 
         self.bin_dir = os.path.join(self.package_dir, 'bin')
         self.local_bin_dir = os.path.join(self.package_dir, 'local', 'bin')
+
+        self.pip_binary = pip_binary
+        self.force_pip_version = force_pip_version
 
         self.preinstall = preinstall
         self.upgrade_pip = upgrade_pip
@@ -108,6 +113,8 @@ class Deployment(object):
                    extra_urls=options.extra_index_url,
                    preinstall=options.preinstall,
                    pip_tool=options.pip_tool,
+                   pip_binary=options.pip_binary,
+                   force_pip_version=options.force_pip_version,
                    upgrade_pip=options.upgrade_pip,
                    index_url=options.index_url,
                    setuptools=options.setuptools,
@@ -151,6 +158,38 @@ class Deployment(object):
 
         virtualenv.append(self.package_dir)
         subprocess.check_call(virtualenv)
+
+        if self.force_pip_version:
+            venv_pip_path = self.venv_bin('pip')
+            print("Forcing / upgrading pip version inside venv to %s..." % (self.force_pip_version))
+            output = subprocess.check_output([venv_pip_path, 'install', '--upgrade',
+                                              'pip==%s' % (self.force_pip_version)]).strip()
+            print('Output: %s' % (output))
+
+        if self.pip_binary:
+            dest_path = self.venv_bin('pip')
+            print("Copying %s pip binary into dh virtualenv: %s..." % (self.pip_binary, dest_path))
+            shutil.copy(self.pip_binary, dest_path)
+
+        # To make troubleshooting, etc. easier, we also print which versions
+        # were copied and used into venv
+        venv_python_path = self.venv_bin('python')
+        venv_virtualenv_path = self.venv_bin('virtualenv')
+        venv_pip_path = self.venv_bin('pip')
+
+        print('dh-virualenv versions info')
+
+        if os.path.exists(venv_python_path):
+            output = subprocess.check_output([venv_python_path, '--version']).strip()
+            print('Using Python: %s' % (output))
+
+        if os.path.exists(venv_virtualenv_path):
+            output = subprocess.check_output([venv_virtualenv_path, '--version']).strip()
+            print('Using virtualenv: %s' % (output))
+
+        if os.path.exists(venv_pip_path):
+            output = subprocess.check_output([venv_pip_path, '--version']).strip()
+            print('Using pip: %s' % (output))
 
     def venv_bin(self, binary_name):
         return os.path.abspath(os.path.join(self.bin_dir, binary_name))


### PR DESCRIPTION
This pull request adds new ``--force-pip-flag`` with which we can force specific pip version to be used inside created virtualenv.

In addition to that, it adds some logging improvements which will make easier to troubleshoot things and assert correct pip version is used.

This change is fully backward compatible if this flag is not used.